### PR TITLE
Add minimal FastAPI backend requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,11 @@
+fastapi
+uvicorn
+python-multipart
+langchain
+qdrant-client
+openai
+pydantic
+python-docx
+pdfplumber
+openpyxl
+python-pptx


### PR DESCRIPTION
## Summary
- add a new `requirements.txt` with minimal dependencies for FastAPI backend

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6878ce312ec8832e8da4aedab68ab642